### PR TITLE
Disable foreign key checks when cleaning tables

### DIFF
--- a/lib/mysql_rewinder/cleaner.rb
+++ b/lib/mysql_rewinder/cleaner.rb
@@ -20,6 +20,7 @@ class MysqlRewinder
       target_tables = (tables - @except_tables) & all_tables
       return if target_tables.empty?
 
+      @client.execute("SET FOREIGN_KEY_CHECKS = 0;")
       @client.execute(target_tables.map { |table| "DELETE FROM #{table}" }.join(';'))
     end
 


### PR DESCRIPTION
### Summary
To prevent foreign key constraint errors when executing `DELETE` on parent tables where child tables have foreign keys referencing them, we temporarily disable `FOREIGN_KEY_CHECKS`.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

